### PR TITLE
Set tinys3 ACL public param to False

### DIFF
--- a/s3cam.py
+++ b/s3cam.py
@@ -47,7 +47,7 @@ while True:
     # Upload to S3
     conn = tinys3.Connection(cfg['s3']['access_key_id'], cfg['s3']['secret_access_key'])
     f = open(filepath, 'rb')
-    conn.upload(filepath, f, cfg['s3']['bucket_name'],
+    conn.upload(filepath, f, cfg['s3']['bucket_name'], public=False,
                headers={
                'x-amz-meta-cache-control': 'max-age=60'
                })


### PR DESCRIPTION
Nice utility for the pi. As currently written the code uses the default ACL parameter for tinys3, which will set the uploaded file's S3 ACL to 'public.' That means the file is readable by anyone with the URL for that file in S3 (even if it's not a 'public' S3 bucket). This overrides that default. Without this change, a user is (likely unknowingly) posting these uploaded pictures publicly on the Internet.